### PR TITLE
Downcase the prefix when normalizing identifiers.

### DIFF
--- a/lib/openurl/context_object_entity.rb
+++ b/lib/openurl/context_object_entity.rb
@@ -246,7 +246,7 @@ module OpenURL
     # into info URIs.  
     def self.normalize_id(value)
         value =~ /^(\w+)(\:|\/)(.*)/
-        prefix = $1
+        prefix = $1.downcase
         remainder = $3
         # info ones
         if ["doi", "pmid", "oclcnum", "sici", "lccn", "sid"].include?(prefix)

--- a/test/context_object_entity_test.rb
+++ b/test/context_object_entity_test.rb
@@ -17,6 +17,7 @@ class ContextObjectEntityTest < Test::Unit::TestCase
      
      
      assert_equal "info:doi/10.1126/science.275.5304.1320", init_and_return_id("doi:10.1126/science.275.5304.1320")
+     assert_equal "info:doi/10.1126/science.275.5304.1320", init_and_return_id("DOI:10.1126/science.275.5304.1320")
      
      assert_equal "info:pmid/9036860", init_and_return_id("pmid:9036860")
      


### PR DESCRIPTION
I found in the wild a version 0.1 openurl that looked like `id=DOI:...` which is treated differently from `id=doi:...`.  Downcasing the prefix changes that.