### PR TITLE
Add rudimentary https:// support to OpenURL::Transport

### DIFF
--- a/lib/openurl/transport.rb
+++ b/lib/openurl/transport.rb
@@ -22,6 +22,8 @@ module OpenURL
     # subsequent requests.  The contextobject argument can be an OpenURL 
     # ContextObject object, and array of ContextObjects or nil.  http_arguments 
     # set the Net::HTTP attributes: {:open_timeout=>3, :read_timeout=>5}, etc.
+    # SSL enabled automatically for https:// target_base_url, override cert
+    # verification with http_arguments[:openssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
     
 		def initialize(target_base_url, contextobject=nil, http_arguments={})      
 			@uri = URI.parse(target_base_url)
@@ -32,6 +34,10 @@ module OpenURL
       @client = Net::HTTP.new(@uri.host, @uri.port)
       @client.open_timeout = (http_arguments[:open_timeout]||3)
       @client.read_timeout = (http_arguments[:read_timeout]||5)
+      if @uri.scheme == 'https'
+        @client.use_ssl = true
+        @client.verify_mode = (http_arguments[:openssl_verify_mode]||OpenSSL::SSL::VERIFY_PEER)
+      end
 		end
 		
     # Can take either an OpenURL::ContextObject or an array of ContextObjects


### PR DESCRIPTION
With Ex Libris moving toward requiring https, some backend integrations we had had against an Alma link resolver started failing.

This merely detects if the resolver URL root passed to `OpenURL::Transport#initialize` is https, and turns on `use_ssl=` for `Net::HTTP`.

Optionally, you can override SSL verification by passing an `OpenSSL::SSL::VERIFY*` value with `http_arguments[:openssl_verify_mode]`. For example, switch off cert validation with

```
OpenURL::Transport.new('https://example.org/resolver', context_object, {openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}
```

I find no existing tests against `OpenURL::Transport` but can add some if it is likely this can be merged.

Note: If this cannot or will not be merged, a simple workaround is extending the transport in a way that wraps the initializer 

```
class TransportWithHTTPS < OpenURL::Transport
  def initialize(...)
    super
    @client.use_ssl = true
  end
end
```